### PR TITLE
Detect network name based on DAG info

### DIFF
--- a/src/components/BlockDAG.js
+++ b/src/components/BlockDAG.js
@@ -9,6 +9,7 @@ const BlockDAGBox = () => {
     const [data, setData] = useState({});
     const [isConnected, setIsConnected] = useState(false);
 
+    const [networkName, setNetworkName] = useState("");
     const [blockCount, setBlockCount] = useState();
     const [headerCount, setHeaderCount] = useState("");
     const [virtualDaaScore, setVirtualDaaScore] = useState("");
@@ -19,6 +20,7 @@ const BlockDAGBox = () => {
 
         console.log('DAG Info ', dag_info)
 
+        setNetworkName(dag_info.networkName)
         setBlockCount(dag_info.blockCount)
         setHeaderCount(dag_info.headerCount)
         setVirtualDaaScore(dag_info.virtualDaaScore)
@@ -29,6 +31,7 @@ const BlockDAGBox = () => {
         initBox();
         const updateInterval = setInterval(async () => {
             const dag_info = await getBlockdagInfo()
+            setNetworkName(dag_info.networkName)
             setBlockCount(dag_info.blockCount)
             setHeaderCount(dag_info.headerCount)
             setVirtualDaaScore(dag_info.virtualDaaScore)
@@ -107,7 +110,7 @@ const BlockDAGBox = () => {
                         Network name
                     </td>
                     <td className="pt-1 text-nowrap">
-                        KASPA MAINNET
+                        {networkName}
                     </td>
                 </tr>
                 <tr>


### PR DESCRIPTION
The network appears to be incorrectly identified; despite the explorer operating on a testnet, the **BLOCKDAG INFO** card still displays it as mainnet. At Karlsen, we operate the explorer across both networks, and it would be beneficial for the correct network to be automatically detected based on the node daemon in use. We fixed it for Kaspa explorer as well. A merge is much appreciated.