### PR TITLE
Rejoin rooms on reconnect

### DIFF
--- a/src/App.js
+++ b/src/App.js
@@ -107,10 +107,11 @@ function App() {
         // socketio
         socket.on('connect', () => {
             setIsConnected(true);
+            socket.emit('last-blocks', "")
+            socket.emit("join-room", "bluescore")
         });
 
         socket.on('disconnect', () => {
-
             setIsConnected(false);
         });
 
@@ -119,12 +120,9 @@ function App() {
             socket.emit("join-room", "blocks")
         })
 
-        socket.emit('last-blocks', "")
-
         socket.on('bluescore', (e) => {
             setBlueScore(e.blueScore)
         })
-        socket.emit("join-room", "bluescore")
 
         socket.on('new-block', (d) => {
             setBlocks([...blocksRef.current, d].slice(-20))


### PR DESCRIPTION
Rejoins rooms on reconnect. 

The ws connection will be automatically restored by socket.io, but since the rooms are not rejoined in the "connect" event handler a browser reload is required to start receiving data again. (The connect event handler is also triggered on reconnects.)
