### PR TITLE
Support for decoding inscriptions other than kasplex

### DIFF
--- a/src/components/AddressInfo.js
+++ b/src/components/AddressInfo.js
@@ -54,6 +54,7 @@ const AddressInfo = () => {
     const [txsInpCache, setTxsInpCache] = useState([])
     const [loadingTxs, setLoadingTxs] = useState(true)
     const [txCount, setTxCount] = useState(null);
+    const [txCountLimitExceeded, setTxCountLimitExceeded] = useState(null);
     const [pageError, setPageError] = useState(false);
 
     const [errorLoadingUtxos, setErrorLoadingUtxos] = useState(false)
@@ -238,8 +239,9 @@ const AddressInfo = () => {
 
         if (view === "transactions") {
             loadTransactionsToShow(addr, 20, (activeTx - 1) * 20)
-            getAddressTxCount(addr).then((totalCount) => {
-                setTxCount(totalCount)
+            getAddressTxCount(addr).then((addressTxCount) => {
+                setTxCount(addressTxCount.total)
+                setTxCountLimitExceeded(addressTxCount.limit_exceeded)
             })
             getAddressUtxos(addr).then(
                 (res) => {
@@ -325,9 +327,17 @@ const AddressInfo = () => {
                         className="addressinfo-header addressinfo-header-border mt-4 mt-sm-4 pt-sm-4 ms-sm-5">Transactions
                         count
                     </div>
-                    <div className="utxo-value ms-sm-5">{txCount !== null ? numberWithCommas(txCount) :
-                        <Spinner animation="border" variant="primary"/>}{errorLoadingUtxos &&
-                        <BiGhost className="error-icon"/>}</div>
+                    <div className="utxo-value ms-sm-5">
+                        {txCount !== null ? (
+                            <>
+                                {txCountLimitExceeded && '>'}
+                                {numberWithCommas(txCount)}
+                            </>
+                        ) : (
+                            <Spinner animation="border" variant="primary"/>
+                        )}
+                        {errorLoadingUtxos && <BiGhost className="error-icon"/>}
+                    </div>
                 </Col>
             </Row>
         </Container>

--- a/src/components/TransactionInfo.js
+++ b/src/components/TransactionInfo.js
@@ -157,6 +157,14 @@ const TransactionInfo = () => {
                                     </Col>
                                 </Row>
                                 <Row className="blockinfo-row">
+                                    <Col className="blockinfo-key" lg={2}>Accepting Block Time</Col>
+                                    <Col className="blockinfo-value" lg={10}>
+                                        {txInfo.accepting_block_time
+                                            ? `${moment(parseInt(txInfo.accepting_block_time)).format("YYYY-MM-DD HH:mm:ss")} (${txInfo.accepting_block_time})`
+                                            : "-"}
+                                    </Col>
+                                </Row>
+                                <Row className="blockinfo-row">
                                     <Col className="blockinfo-key" lg={2}>Payload</Col>
                                     <Col className="blockinfo-value-mono" lg={10}>
                                             {txInfo.payload || "-"}

--- a/src/components/TransactionInfo.js
+++ b/src/components/TransactionInfo.js
@@ -95,7 +95,12 @@ const TransactionInfo = () => {
             setTimeout(getTx, 2000);
         }
 
-
+        if (txInfo?.inputs) {
+            txInfo.inputs.forEach(input => {
+                const parsedSignatureScript = parseSignatureScript(input.signature_script);
+                input.inscription = parsedSignatureScript?.findLast(s => s[0] === 'OP_PUSHDATA1')?.[1];
+            })
+        }
     }, [txInfo])
 
 
@@ -229,11 +234,11 @@ const TransactionInfo = () => {
                                                 <div className="utxo-value-mono">
                                                     {tx_input.signature_script}
                                                 </div>
-                                                {tx_input.signature_script.includes('6b6173706c6578') && (
+                                                {tx_input.inscription && (
                                                     <>
-                                                        <div className="blockinfo-key mt-2">KRC-20</div>
+                                                        <div className="blockinfo-key mt-2">Inscription</div>
                                                         <div className="utxo-value-mono" style={{ whiteSpace: "pre-wrap" }}>
-                                                            {parseSignatureScript(tx_input.signature_script).findLast(s => s.indexOf('OP_PUSH') === 0).split(' ')[1]}
+                                                            {tx_input.inscription}
                                                         </div>
                                                     </>
                                                 )}

--- a/src/inscriptions.js
+++ b/src/inscriptions.js
@@ -1,12 +1,15 @@
 export const parseSignatureScript = (hex) => {
-    /* Decodes KRC-20 operations */
-    /* Example tx deploy: 105424172e946f85daf87f50422e4a5a7f73d541a7a0eaf666cf40567a80ba5d */
-    /* Example tx mint: e2792d606f7cae9994cbc233a2cdb9c4d4541ad195852ae8ecfd787254613ded */
-    /* Example tx transfer: 657a7a3dbe5c6af4e49eba4c0cf82753f01d5e721f458d356f62bebd0afd54c8 */
+    /* Decodes inscriptions */
+    /* KRC-20 tx deploy: 105424172e946f85daf87f50422e4a5a7f73d541a7a0eaf666cf40567a80ba5d */
+    /* KRC-20 tx mint: e2792d606f7cae9994cbc233a2cdb9c4d4541ad195852ae8ecfd787254613ded */
+    /* KRC-20 tx transfer: 657a7a3dbe5c6af4e49eba4c0cf82753f01d5e721f458d356f62bebd0afd54c8 */
+    /* KRC-721 tx transfer: ec13b8e75a8e82a2e13fe41cd03cff770978dd52d09a8d3b79c66625a8e3cb08 */
     if (!hex) {
         return;
     }
-    return parseSignature(hexToBytes(hex));
+    let parsedSignature = parseSignature(hexToBytes(hex));
+    // console.debug(parsedSignature);
+    return parsedSignature;
 }
 
 function parseSignature(bytes) {
@@ -20,9 +23,9 @@ function parseSignature(bytes) {
             const dataLength = opcode;
             const data = bytes.slice(offset, offset + dataLength);
             if (isHumanReadable(data)) {
-                result.push(`OP_PUSH ${bytesToString(data)}`);
+                result.push(['OP_PUSH', bytesToString(data)]);
             } else {
-                result.push(`OP_PUSH ${bytesToHex(data)}`);
+                result.push(['OP_PUSH', bytesToHex(data)]);
             }
             offset += dataLength;
         } else if (opcode === 0x4c) {
@@ -30,23 +33,23 @@ function parseSignature(bytes) {
             offset += 1;
             const data = bytes.slice(offset, offset + dataLength);
             if (isHumanReadable(data)) {
-                result.push(`OP_PUSHDATA1 ${bytesToString(data)}`);
+                result.push(['OP_PUSHDATA1', bytesToString(data)]);
             } else {
                 result = result.concat(parseSignature(data));
             }
             offset += dataLength;
         } else if (opcode === 0x00) {
-            result.push('OP_0')
+            result.push(['OP_0'])
         } else if (opcode === 0x51) {
-            result.push('OP_1')
+            result.push(['OP_1'])
         } else if (opcode === 0x63) {
-            result.push('OP_IF')
+            result.push(['OP_IF'])
         } else if (opcode === 0x68) {
-            result.push('OP_ENDIF')
+            result.push(['OP_ENDIF'])
         } else if (opcode === 0xac) {
-            result.push('OP_CHECKSIG')
+            result.push(['OP_CHECKSIG'])
         } else {
-            result.push(`OP_UNKNOWN ${bytesToHex(opcode)}`)
+            result.push(['OP_UNKNOWN', bytesToHex(opcode)])
         }
     }
     return result;

--- a/src/kaspa-api-client.js
+++ b/src/kaspa-api-client.js
@@ -80,7 +80,7 @@ export async function getAddressTxCount(addr) {
     const res = await fetch(`${API_BASE}addresses/${addr}/transactions-count`, {headers: {'Access-Control-Allow-Origin': '*'}})
         .then((response) => response.json())
         .then(data => {
-            return data.total
+            return data
         })
     return res
 }


### PR DESCRIPTION
Removes the condition on the signature script containing the word 'kasplex'.
Also moves the decoding to not be part of view rendering (=performance improvement).