### PR TITLE
Enable cors cookies for socketio

### DIFF
--- a/src/App.js
+++ b/src/App.js
@@ -46,7 +46,8 @@ document.addEventListener("DOMContentLoaded", function () {
 });
 
 const socket = io(SOCKET_SERVER, {
-    path: '/ws/socket.io'
+    path: '/ws/socket.io',
+    withCredentials: true // Supports session cookies on cross-origin requests
 });
 
 function App() {


### PR DESCRIPTION
Allows the use of cookie based session tracking for the explorer socketio requests