### PR TITLE
TransactionInfo.js: resolve_previous_outpoints=light for tx

### DIFF
--- a/src/kaspa-api-client.js
+++ b/src/kaspa-api-client.js
@@ -12,7 +12,8 @@ export async function getBlock(hash) {
 }
 
 export async function getTransaction(hash, blockHash) {
-    const queryParams = blockHash ? `?blockHash=${blockHash}` : '';
+    let queryParams = "?resolve_previous_outpoints=light"
+    queryParams += blockHash ? `&blockHash=${blockHash}` : '';
     const res = await fetch(`${API_BASE}transactions/${hash}${queryParams}`, {headers: {'Access-Control-Allow-Origin': '*'}})
         .then((response) => response.json())
         .then(data => {


### PR DESCRIPTION
TransactionInfo.js: resolve_previous_outpoints=light for initial transaction lookup avoiding a second search to resolve inputs.
More importantly, enables tx input addresses for utxo imported outputs (tn10 explorer).
Ideally the block and address pages should be fixed as well.